### PR TITLE
Add stratified k-fold, classification CV, grid search, clustering CLI, softmax, early stopping

### DIFF
--- a/cross_validation.cpp
+++ b/cross_validation.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <map>
 #include <random>
 #include <ranges>
 #include <vector>
@@ -41,6 +42,46 @@ kFoldSplit(size_t n_samples, int k, unsigned int seed) {
                          indices.begin() + static_cast<ptrdiff_t>(end),
                          indices.end());
 
+    folds.push_back({train_indices, test_indices});
+  }
+
+  return folds;
+}
+
+std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
+stratifiedKFoldSplit(const Vector &y, int k, unsigned int seed) {
+  std::map<int, std::vector<size_t>> class_indices;
+  for (size_t i = 0; i < y.size(); i++)
+    class_indices[static_cast<int>(y[i])].push_back(i);
+
+  std::default_random_engine rng(seed);
+  for (auto &[cls, indices] : class_indices)
+    std::ranges::shuffle(indices, rng);
+
+  std::vector<std::vector<size_t>> fold_indices(static_cast<size_t>(k));
+  for (const auto &[cls, indices] : class_indices) {
+    size_t n = indices.size();
+    size_t fold_size = n / static_cast<size_t>(k);
+    size_t remainder = n % static_cast<size_t>(k);
+    size_t pos = 0;
+    for (int f = 0; f < k; f++) {
+      size_t count = fold_size + (static_cast<size_t>(f) < remainder ? 1 : 0);
+      for (size_t j = 0; j < count; j++)
+        fold_indices[static_cast<size_t>(f)].push_back(indices[pos++]);
+    }
+  }
+
+  std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>> folds;
+  for (int i = 0; i < k; i++) {
+    std::vector<size_t> test_indices = fold_indices[static_cast<size_t>(i)];
+    std::vector<size_t> train_indices;
+    for (int j = 0; j < k; j++) {
+      if (j != i) {
+        train_indices.insert(train_indices.end(),
+                             fold_indices[static_cast<size_t>(j)].begin(),
+                             fold_indices[static_cast<size_t>(j)].end());
+      }
+    }
     folds.push_back({train_indices, test_indices});
   }
 

--- a/supervised/logistic_regression.cpp
+++ b/supervised/logistic_regression.cpp
@@ -1,4 +1,5 @@
 #include "../matrix.h"
+#include <algorithm>
 #include <cmath>
 
 class LogisticRegression {
@@ -69,4 +70,85 @@ public:
   double getBias() const { return bias; }
   void setWeights(const Vector &w) { weights = w; }
   void setBias(double b) { bias = b; }
+};
+
+class SoftmaxRegression {
+private:
+  Matrix weights;
+  Vector biases;
+  double learningRate;
+  int maxIterations;
+  int nClasses = 0;
+
+  Vector softmax(const Vector &z) const {
+    double maxZ = *std::max_element(z.begin(), z.end());
+    Vector exp_z(z.size());
+    double sum = 0.0;
+    for (size_t i = 0; i < z.size(); i++) {
+      exp_z[i] = std::exp(z[i] - maxZ);
+      sum += exp_z[i];
+    }
+    for (double &v : exp_z)
+      v /= sum;
+    return exp_z;
+  }
+
+public:
+  SoftmaxRegression(double learningRate = 0.01, int maxIterations = 1000)
+      : learningRate(learningRate), maxIterations(maxIterations) {}
+
+  void fit(const Matrix &X, const Vector &y) {
+    size_t n_samples = X.size();
+    size_t n_features = X[0].size();
+
+    nClasses = 0;
+    for (double v : y)
+      nClasses = std::max(nClasses, static_cast<int>(v) + 1);
+
+    weights = Matrix(n_features, Vector(nClasses, 0.0));
+    biases = Vector(nClasses, 0.0);
+
+    for (int iter = 0; iter < maxIterations; iter++) {
+      Matrix dw(n_features, Vector(nClasses, 0.0));
+      Vector db(nClasses, 0.0);
+
+      for (size_t i = 0; i < n_samples; i++) {
+        Vector z(nClasses, 0.0);
+        for (int c = 0; c < nClasses; c++) {
+          z[c] = biases[c];
+          for (size_t j = 0; j < n_features; j++)
+            z[c] += weights[j][c] * X[i][j];
+        }
+
+        Vector probs = softmax(z);
+        int label = static_cast<int>(y[i]);
+
+        for (int c = 0; c < nClasses; c++) {
+          double grad = probs[c] - (c == label ? 1.0 : 0.0);
+          for (size_t j = 0; j < n_features; j++)
+            dw[j][c] += grad * X[i][j];
+          db[c] += grad;
+        }
+      }
+
+      auto n = static_cast<double>(n_samples);
+      for (size_t j = 0; j < n_features; j++)
+        for (int c = 0; c < nClasses; c++)
+          weights[j][c] -= learningRate * dw[j][c] / n;
+      for (int c = 0; c < nClasses; c++)
+        biases[c] -= learningRate * db[c] / n;
+    }
+  }
+
+  double predict(const Vector &x) const {
+    Vector z(nClasses, 0.0);
+    for (int c = 0; c < nClasses; c++) {
+      z[c] = biases[c];
+      for (size_t j = 0; j < x.size(); j++)
+        z[c] += weights[j][c] * x[j];
+    }
+    Vector probs = softmax(z);
+    return static_cast<double>(
+        std::max_element(probs.begin(), probs.end()) - probs.begin());
+  }
 };


### PR DESCRIPTION
## Summary
- **Stratified K-Fold**: `stratifiedKFoldSplit` preserves class proportions across folds, used automatically for classification CV
- **Classification CV**: `cv` mode now runs both regression and classification cross-validation, with metrics derived from each algorithm's result instead of hardcoded R²
- **Expanded Grid Search**: Added grid search for Decision Tree (`maxDepth`), Random Forest (`n_trees`, `max_features`), XGBoost Regressor (`learning_rate`, `max_depth`), and Logistic Regression (`learning_rate`)
- **Clustering CLI**: New `cluster` mode runs k-means, DBSCAN, agglomerative, and spectral clustering with silhouette score reporting
- **Softmax Regression**: Multiclass logistic regression via softmax activation and cross-entropy loss, registered as `softmax`
- **Early Stopping**: GBT and XGBoost (both regressor and classifier) gain optional `validationFraction`/`patience` params; new `-es` algorithm variants use 20% validation holdout

## Test plan
- [x] `cmake -B build && cmake --build build` compiles without errors
- [x] `bazel build //:ml-algos` compiles without errors
- [x] `./build/ml-algos sample_data.csv` shows scores for all new algorithms (softmax, *-es variants)
- [x] `./build/ml-algos sample_data.csv cv` runs regression + classification CV
- [x] `./build/ml-algos sample_data.csv gridsearch` shows expanded grid search results
- [x] `./build/ml-algos sample_data.csv cluster` reports silhouette scores for 4 clustering algorithms