### PR TITLE
Add span-friendly pipeline APIs

### DIFF
--- a/ml/io/csv.cc
+++ b/ml/io/csv.cc
@@ -1,5 +1,6 @@
 #include "ml/io/csv.h"
 
+#include <algorithm>
 #include <charconv>
 #include <fstream>
 #include <string>
@@ -30,9 +31,8 @@ std::vector<std::string> SplitCsvLine(std::string_view line) {
   return cells;
 }
 
-std::expected<double, std::string> ParseDouble(std::string_view text,
-                                               std::size_t row,
-                                               std::string_view column) {
+std::expected<double, std::string>
+ParseDouble(std::string_view text, std::size_t row, std::string_view column) {
   double value = 0.0;
   const char *begin = text.data();
   const char *end = text.data() + text.size();
@@ -114,16 +114,12 @@ ReadDatasetCsv(const std::string &path, const std::string &target_column) {
     return std::unexpected(table.error());
   }
 
-  std::size_t target_index = table->column_names.size();
-  for (std::size_t index = 0; index < table->column_names.size(); ++index) {
-    if (table->column_names[index] == target_column) {
-      target_index = index;
-      break;
-    }
-  }
-  if (target_index == table->column_names.size()) {
+  const auto target_it = std::ranges::find(table->column_names, target_column);
+  if (target_it == table->column_names.end()) {
     return std::unexpected("target column not found: " + target_column);
   }
+  const std::size_t target_index =
+      static_cast<std::size_t>(target_it - table->column_names.begin());
   if (table->column_names.size() < 2) {
     return std::unexpected("dataset must include at least one feature column");
   }
@@ -154,7 +150,7 @@ ReadDatasetCsv(const std::string &path, const std::string &target_column) {
 
 std::expected<ml::core::DenseMatrix, std::string>
 SelectFeatureColumns(const NumericTable &table,
-                     const std::vector<std::string> &feature_names) {
+                     std::span<const std::string> feature_names) {
   std::unordered_map<std::string, std::size_t> index_by_name;
   for (std::size_t index = 0; index < table.column_names.size(); ++index) {
     index_by_name[table.column_names[index]] = index;
@@ -172,6 +168,17 @@ SelectFeatureColumns(const NumericTable &table,
     }
   }
   return selected;
+}
+
+std::expected<ml::core::DenseMatrix, std::string>
+SelectFeatureColumns(const NumericTable &table,
+                     std::initializer_list<std::string_view> feature_names) {
+  std::vector<std::string> owned_names;
+  owned_names.reserve(feature_names.size());
+  for (std::string_view name : feature_names) {
+    owned_names.emplace_back(name);
+  }
+  return SelectFeatureColumns(table, std::span<const std::string>(owned_names));
 }
 
 } // namespace ml::io

--- a/ml/io/csv.h
+++ b/ml/io/csv.h
@@ -2,7 +2,10 @@
 #define ML_IO_CSV_H_
 
 #include <expected>
+#include <initializer_list>
+#include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "ml/core/dense_matrix.h"
@@ -21,7 +24,10 @@ std::expected<TabularDataset, std::string>
 ReadDatasetCsv(const std::string &path, const std::string &target_column);
 std::expected<core::DenseMatrix, std::string>
 SelectFeatureColumns(const NumericTable &table,
-                     const std::vector<std::string> &feature_names);
+                     std::span<const std::string> feature_names);
+std::expected<core::DenseMatrix, std::string>
+SelectFeatureColumns(const NumericTable &table,
+                     std::initializer_list<std::string_view> feature_names);
 
 } // namespace ml::io
 

--- a/ml/models/models.cc
+++ b/ml/models/models.cc
@@ -1,9 +1,9 @@
 #include "ml/models/interfaces.h"
 
-#include <charconv>
-#include <concepts>
 #include <algorithm>
+#include <charconv>
 #include <cmath>
+#include <concepts>
 #include <limits>
 #include <memory>
 #include <numbers>
@@ -252,7 +252,7 @@ double Sigmoid(double value) {
 }
 
 Vector Softmax(const Vector &logits) {
-  const double max_logit = *std::max_element(logits.begin(), logits.end());
+  const double max_logit = *std::ranges::max_element(logits);
   Vector probabilities(logits.size(), 0.0);
   double sum = 0.0;
   for (std::size_t index = 0; index < logits.size(); ++index) {
@@ -268,9 +268,9 @@ Vector Softmax(const Vector &logits) {
 LabelVector ArgMaxLabels(const DenseMatrix &probabilities) {
   LabelVector labels(probabilities.rows(), 0);
   for (std::size_t row = 0; row < probabilities.rows(); ++row) {
-    labels[row] = static_cast<int>(
-        std::max_element(probabilities[row].begin(), probabilities[row].end()) -
-        probabilities[row].begin());
+    const auto probabilities_row = probabilities[row];
+    labels[row] = static_cast<int>(std::ranges::max_element(probabilities_row) -
+                                   probabilities_row.begin());
   }
   return labels;
 }
@@ -604,11 +604,9 @@ public:
           static_cast<std::size_t>(std::max(spec_.k, 1));
       const std::size_t k = std::min(requested_k, distances.size());
       if (k < distances.size()) {
-        std::nth_element(distances.begin(),
-                         distances.begin() + static_cast<std::ptrdiff_t>(k),
-                         distances.end(), [](const auto &lhs, const auto &rhs) {
-                           return lhs.first < rhs.first;
-                         });
+        std::ranges::nth_element(
+            distances, distances.begin() + static_cast<std::ptrdiff_t>(k), {},
+            &std::pair<double, double>::first);
       }
       double total = 0.0;
       for (std::size_t index = 0; index < k; ++index) {
@@ -788,10 +786,7 @@ private:
       for (std::size_t index : indices) {
         pairs.emplace_back(features[index][feature], targets[index]);
       }
-      std::sort(pairs.begin(), pairs.end(),
-                [](const auto &lhs, const auto &rhs) {
-                  return lhs.first < rhs.first;
-                });
+      std::ranges::sort(pairs, {}, &std::pair<double, double>::first);
       std::vector<double> prefix_sum(pairs.size(), 0.0);
       std::vector<double> prefix_sq(pairs.size(), 0.0);
       for (std::size_t index = 0; index < pairs.size(); ++index) {
@@ -874,8 +869,8 @@ private:
       return nullptr;
     }
     if (line->starts_with("leaf ")) {
-      auto value = ParseNumber<double>(line->substr(5),
-                                       "regression tree leaf value");
+      auto value =
+          ParseNumber<double>(line->substr(5), "regression tree leaf value");
       if (!value) {
         return std::unexpected(value.error());
       }
@@ -891,15 +886,13 @@ private:
     if (separator == std::string_view::npos) {
       return std::unexpected("invalid regression tree split");
     }
-    auto feature =
-        ParseNumber<std::size_t>(payload.substr(0, separator),
-                                 "regression tree split feature");
+    auto feature = ParseNumber<std::size_t>(payload.substr(0, separator),
+                                            "regression tree split feature");
     if (!feature) {
       return std::unexpected(feature.error());
     }
-    auto threshold =
-        ParseNumber<double>(payload.substr(separator + 1),
-                            "regression tree split threshold");
+    auto threshold = ParseNumber<double>(payload.substr(separator + 1),
+                                         "regression tree split threshold");
     if (!threshold) {
       return std::unexpected(threshold.error());
     }
@@ -1004,9 +997,8 @@ public:
 
   int Predict(DenseMatrix::ConstRow row) const {
     const Vector probabilities = PredictProba(row);
-    return static_cast<int>(
-        std::max_element(probabilities.begin(), probabilities.end()) -
-        probabilities.begin());
+    return static_cast<int>(std::ranges::max_element(probabilities) -
+                            probabilities.begin());
   }
 
   std::string SaveState() const {
@@ -1030,7 +1022,8 @@ public:
     if (!line) {
       return std::unexpected(line.error());
     }
-    auto class_count = ParseNumber<int>(*line, "classification tree class count");
+    auto class_count =
+        ParseNumber<int>(*line, "classification tree class count");
     if (!class_count) {
       return std::unexpected(class_count.error());
     }
@@ -1078,8 +1071,7 @@ private:
       value /= static_cast<double>(indices.size());
     }
     node->predicted_class =
-        static_cast<int>(std::max_element(node->probabilities.begin(),
-                                          node->probabilities.end()) -
+        static_cast<int>(std::ranges::max_element(node->probabilities) -
                          node->probabilities.begin());
 
     if (depth >= max_depth_ ||
@@ -1096,10 +1088,7 @@ private:
       for (std::size_t index : indices) {
         pairs.emplace_back(features[index][feature], labels[index]);
       }
-      std::sort(pairs.begin(), pairs.end(),
-                [](const auto &lhs, const auto &rhs) {
-                  return lhs.first < rhs.first;
-                });
+      std::ranges::sort(pairs, {}, &std::pair<double, int>::first);
       std::vector<int> left_counts(static_cast<std::size_t>(class_count_), 0);
       std::vector<int> right_counts(static_cast<std::size_t>(class_count_), 0);
       for (const auto &pair : pairs) {
@@ -1188,9 +1177,8 @@ private:
       if (separator == std::string_view::npos) {
         return std::unexpected("invalid classification tree leaf");
       }
-      auto predicted_class =
-          ParseNumber<int>(payload.substr(0, separator),
-                           "classification tree predicted class");
+      auto predicted_class = ParseNumber<int>(
+          payload.substr(0, separator), "classification tree predicted class");
       if (!predicted_class) {
         return std::unexpected(predicted_class.error());
       }
@@ -1211,15 +1199,13 @@ private:
     if (separator == std::string_view::npos) {
       return std::unexpected("invalid classification tree split");
     }
-    auto feature =
-        ParseNumber<std::size_t>(payload.substr(0, separator),
-                                 "classification tree split feature");
+    auto feature = ParseNumber<std::size_t>(
+        payload.substr(0, separator), "classification tree split feature");
     if (!feature) {
       return std::unexpected(feature.error());
     }
-    auto threshold =
-        ParseNumber<double>(payload.substr(separator + 1),
-                            "classification tree split threshold");
+    auto threshold = ParseNumber<double>(payload.substr(separator + 1),
+                                         "classification tree split threshold");
     if (!threshold) {
       return std::unexpected(threshold.error());
     }
@@ -1357,7 +1343,7 @@ public:
 
   std::expected<void, std::string> Fit(const DenseMatrix &features,
                                        std::span<const int> labels) override {
-    const int max_label = *std::max_element(labels.begin(), labels.end());
+    const int max_label = *std::ranges::max_element(labels);
     class_count_ = static_cast<std::size_t>(max_label) + 1;
     weights_ = DenseMatrix(features.cols(), class_count_, 0.0);
     biases_.assign(class_count_, 0.0);
@@ -1495,7 +1481,7 @@ public:
 
   std::expected<void, std::string> Fit(const DenseMatrix &features,
                                        std::span<const int> labels) override {
-    const int max_label = *std::max_element(labels.begin(), labels.end());
+    const int max_label = *std::ranges::max_element(labels);
     class_count_ = static_cast<std::size_t>(max_label) + 1;
     priors_.assign(class_count_, 0.0);
     means_ = DenseMatrix(class_count_, features.cols(), 0.0);
@@ -1689,11 +1675,9 @@ public:
           static_cast<std::size_t>(std::max(spec_.k, 1));
       const std::size_t k = std::min(requested_k, distances.size());
       if (k < distances.size()) {
-        std::nth_element(distances.begin(),
-                         distances.begin() + static_cast<std::ptrdiff_t>(k),
-                         distances.end(), [](const auto &lhs, const auto &rhs) {
-                           return lhs.first < rhs.first;
-                         });
+        std::ranges::nth_element(
+            distances, distances.begin() + static_cast<std::ptrdiff_t>(k), {},
+            &std::pair<double, int>::first);
       }
       for (std::size_t index = 0; index < k; ++index) {
         probabilities[row][static_cast<std::size_t>(distances[index].second)] +=
@@ -1907,11 +1891,13 @@ public:
       if (!line) {
         return std::unexpected(line.error());
       }
-      auto size = ParseNumber<std::size_t>(*line, "random forest regressor size");
+      auto size =
+          ParseNumber<std::size_t>(*line, "random forest regressor size");
       if (!size) {
         return std::unexpected(size.error());
       }
-      auto buffer = reader.ReadChunk(*size, "invalid random forest regressor state");
+      auto buffer =
+          reader.ReadChunk(*size, "invalid random forest regressor state");
       if (!buffer) {
         return std::unexpected(buffer.error());
       }

--- a/ml/pipeline/pipeline.cc
+++ b/ml/pipeline/pipeline.cc
@@ -41,7 +41,7 @@ ValidateDataset(const TabularDataset &dataset) {
 }
 
 TabularDataset SliceDataset(const TabularDataset &dataset,
-                            const std::vector<std::size_t> &indices) {
+                            std::span<const std::size_t> indices) {
   TabularDataset out;
   out.schema = dataset.schema;
   out.features = dataset.features.SliceRows(indices);
@@ -87,7 +87,7 @@ EncodeLabels(std::span<const double> targets) {
 }
 
 std::expected<LabelVector, std::string>
-DecodeLabels(std::span<const int> encoded, const std::vector<int> &original) {
+DecodeLabels(std::span<const int> encoded, std::span<const int> original) {
   LabelVector labels;
   labels.reserve(encoded.size());
   for (int value : encoded) {
@@ -531,9 +531,12 @@ std::expected<FoldSet, std::string> MakeKFoldSet(const TabularDataset &dataset,
 
 std::expected<EvaluationReport, std::string>
 EvaluateSplit(const Split &split, Task task,
-              const std::vector<preprocess::TransformerSpec> &transformer_specs,
+              std::span<const preprocess::TransformerSpec> transformer_specs,
               const models::EstimatorSpec &estimator_spec) {
-  Pipeline pipeline(task, transformer_specs, estimator_spec);
+  Pipeline pipeline(task,
+                    std::vector<preprocess::TransformerSpec>(
+                        transformer_specs.begin(), transformer_specs.end()),
+                    estimator_spec);
   auto status = pipeline.Fit(split.train);
   if (!status) {
     return std::unexpected(status.error());
@@ -541,11 +544,24 @@ EvaluateSplit(const Split &split, Task task,
   return EvaluateFittedPipeline(pipeline, split);
 }
 
+std::expected<EvaluationReport, std::string> EvaluateSplit(
+    const Split &split, Task task,
+    std::initializer_list<preprocess::TransformerSpec> transformer_specs,
+    const models::EstimatorSpec &estimator_spec) {
+  return EvaluateSplit(split, task,
+                       std::span<const preprocess::TransformerSpec>(
+                           transformer_specs.begin(), transformer_specs.size()),
+                       estimator_spec);
+}
+
 std::expected<FitArtifacts, std::string>
 FitSplit(const Split &split, Task task,
-         const std::vector<preprocess::TransformerSpec> &transformer_specs,
+         std::span<const preprocess::TransformerSpec> transformer_specs,
          const models::EstimatorSpec &estimator_spec) {
-  Pipeline pipeline(task, transformer_specs, estimator_spec);
+  Pipeline pipeline(task,
+                    std::vector<preprocess::TransformerSpec>(
+                        transformer_specs.begin(), transformer_specs.end()),
+                    estimator_spec);
   auto status = pipeline.Fit(split.train);
   if (!status) {
     return std::unexpected(status.error());
@@ -562,6 +578,16 @@ FitSplit(const Split &split, Task task,
   artifacts.report = std::move(*report);
   artifacts.bundle = std::move(*bundle);
   return artifacts;
+}
+
+std::expected<FitArtifacts, std::string>
+FitSplit(const Split &split, Task task,
+         std::initializer_list<preprocess::TransformerSpec> transformer_specs,
+         const models::EstimatorSpec &estimator_spec) {
+  return FitSplit(split, task,
+                  std::span<const preprocess::TransformerSpec>(
+                      transformer_specs.begin(), transformer_specs.size()),
+                  estimator_spec);
 }
 
 std::expected<TuneReport, std::string>

--- a/ml/pipeline/pipeline.h
+++ b/ml/pipeline/pipeline.h
@@ -2,6 +2,7 @@
 #define ML_PIPELINE_PIPELINE_H_
 
 #include <expected>
+#include <initializer_list>
 #include <memory>
 #include <span>
 #include <string>
@@ -64,11 +65,19 @@ std::expected<FoldSet, std::string> MakeKFoldSet(const TabularDataset &dataset,
                                                  unsigned int seed);
 std::expected<EvaluationReport, std::string>
 EvaluateSplit(const Split &split, Task task,
-              const std::vector<preprocess::TransformerSpec> &transformer_specs,
+              std::span<const preprocess::TransformerSpec> transformer_specs,
               const models::EstimatorSpec &estimator_spec);
+std::expected<EvaluationReport, std::string> EvaluateSplit(
+    const Split &split, Task task,
+    std::initializer_list<preprocess::TransformerSpec> transformer_specs,
+    const models::EstimatorSpec &estimator_spec);
 std::expected<FitArtifacts, std::string>
 FitSplit(const Split &split, Task task,
-         const std::vector<preprocess::TransformerSpec> &transformer_specs,
+         std::span<const preprocess::TransformerSpec> transformer_specs,
+         const models::EstimatorSpec &estimator_spec);
+std::expected<FitArtifacts, std::string>
+FitSplit(const Split &split, Task task,
+         std::initializer_list<preprocess::TransformerSpec> transformer_specs,
          const models::EstimatorSpec &estimator_spec);
 std::expected<TuneReport, std::string>
 GridSearch(const FoldSet &folds, Task task,


### PR DESCRIPTION
## Summary
- accept spans for selected pipeline and CSV helper APIs
- add initializer-list overloads for common call sites
- modernize internal algorithm calls with ranges helpers

## Validation
- `bazel test //...` could not run because the checkout pins Bazel 9.0.0 and the local Homebrew Bazel install is missing that binary